### PR TITLE
Fix missing newline in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # hello-world
+
+A minimal repository demonstrating newline fix.


### PR DESCRIPTION
## Summary
- fix missing newline in README causing prompts to appear on same line
- document repository purpose

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fca36390c83338071b28f4e501653